### PR TITLE
Fix multiple mount usb disks, after restart, entware can not be started

### DIFF
--- a/release/src/router/others/entware-setup.sh
+++ b/release/src/router/others/entware-setup.sh
@@ -139,11 +139,11 @@ chmod +x /jffs/scripts/services-stop
 cat > /jffs/scripts/post-mount << EOF
 #!/bin/sh
 
-if [ "\$1" = "__Partition__" ] ; then
+if [ -d "\$1/entware" ] ; then
   ln -nsf \$1/entware /tmp/opt
 fi
 EOF
-eval sed -i 's,__Partition__,$entPartition,g' /jffs/scripts/post-mount
+# eval sed -i 's,__Partition__,$entPartition,g' /jffs/scripts/post-mount
 chmod +x /jffs/scripts/post-mount
 
 if [ "$(nvram get jffs2_scripts)" != "1" ] ; then


### PR DESCRIPTION
Multiple mounts of usb disk, after reboot, the mount directory changes, resulting in the entware directory not found.